### PR TITLE
Enemy cannot be targeted once dead

### DIFF
--- a/gym_sts/envs/utils.py
+++ b/gym_sts/envs/utils.py
@@ -87,8 +87,13 @@ class ActionValidators:
             return False
 
         enemies = observation.combat_state.enemies
-        if target_index is not None and target_index >= len(enemies):
-            return False
+        if target_index is not None:
+            if target_index >= len(enemies):
+                return False
+
+            enemy = enemies[target_index]
+            if enemy["is_gone"]:
+                return False
 
         return card.is_playable
 


### PR DESCRIPTION
It appears that enemies are not removed from the communicationmod response after they're killed, so we have to check their properties to determine if they're dead.