### PR TITLE
Add superfastmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ All installation commands are expected to be run as root.
 
 - Java JDK 8
 - Docker
+- A copy of Slay the Spire, particularly its `desktop-1.0.jar` file.
+- The JAR files for several mods:
+  - ModTheSpire
+  - BaseMod
+  - CommunicationMod
+  - SuperFastMode
 
 # Installation
 
@@ -36,6 +42,7 @@ gym-sts/
   mods/
     BaseMod.jar
     CommunicationMod.jar
+    SuperFastMode.jar
 ```
 
 # Build

--- a/gym_sts/build/Dockerfile
+++ b/gym_sts/build/Dockerfile
@@ -35,4 +35,4 @@ WORKDIR /game
 COPY pipe_to_host.sh pipe_to_host.sh
 
 ENTRYPOINT ["xvfb-run", "-e", "/dev/stdout", "-f", "/tmp/sts.xauth"]
-CMD ["java", "-jar", "/game/lib/ModTheSpire.jar", "--skip-intro", "--mods", "basemod,CommunicationMod"]
+CMD ["java", "-jar", "/game/lib/ModTheSpire.jar", "--skip-intro", "--mods", "basemod,CommunicationMod,superfastmode"]

--- a/gym_sts/constants.py
+++ b/gym_sts/constants.py
@@ -4,6 +4,11 @@ PROJECT_ROOT = Path(__file__).parent.absolute()
 
 JAVA_INSTALL = "/usr/bin/java"
 MTS_JAR = "ModTheSpire.jar"
-EXTRA_ARGS = ["--skip-launcher", "--skip-intro", "--mods", "basemod,CommunicationMod"]
+EXTRA_ARGS = [
+    "--skip-launcher",
+    "--skip-intro",
+    "--mods",
+    "basemod,CommunicationMod,superfastmode",
+]
 
 DOCKER_IMAGE_TAG = "sts"


### PR DESCRIPTION
Adds superfastmode mod for both head-full and headless execution. The mod is now a dependency of the project, and you will get an error if you try to run without it.