### PR TITLE
Fix action validation and observation guarantees

### DIFF
--- a/gym_sts/communication/communicator.py
+++ b/gym_sts/communication/communicator.py
@@ -1,4 +1,5 @@
 import os
+import time
 from pathlib import Path
 
 from gym_sts.communication.receiver import Receiver
@@ -64,8 +65,16 @@ class Communicator:
     def start(self, player_class: str, ascension: int, seed: str) -> Observation:
         self.receiver.empty_fifo()
         self.sender.send_start(player_class, ascension, seed)
-        state = self.receiver.receive_game_state()
-        return Observation(state)
+
+        tries = 3
+        for _ in range(tries):
+            state = self.receiver.receive_game_state()
+            if state["in_game"]:
+                return Observation(state)
+
+            time.sleep(0.05)
+
+        raise TimeoutError("Waited for game to start, but it didn't happen.")
 
     def state(self) -> Observation:
         """

--- a/gym_sts/envs/utils.py
+++ b/gym_sts/envs/utils.py
@@ -36,7 +36,7 @@ class ActionValidators:
             return False
 
         if observation.in_combat:
-            if observation.screen_type == "HAND_SELECT":
+            if observation.screen_type in ["GRID", "HAND_SELECT"]:
                 return cls._validate_choice(action, observation)
             else:
                 # TODO determine if there are any other choices that could
@@ -138,8 +138,15 @@ class ActionValidators:
         potion = potions[index]
 
         target_index = action.target_index
-        if target_index is not None and not potion.requires_target:
-            return False
+
+        # Technically it should be invalid to specify a target if the card
+        # doesn't take a target (and this would cut down on the number of valid
+        # actions), but the game simply ignores the target choice, so it's not an
+        # error. Because we only want actions to be invalid if the game truly won't
+        # accept them, we've commented this validation check out for now.
+        # if target_index is not None and not potion.requires_target:
+        #     return False
+
         if target_index is None and potion.requires_target:
             return False
 


### PR DESCRIPTION
- It's not an error to specify a target for potions that don't take a target
- Add validation for grid selections in combat (e.g. hologram)
- Attempt to resolve apparent communicationmod race condition where observation response from the "start" command isn't in-game.