### PR TITLE
Correct env validation of potion usage

### DIFF
--- a/gym_sts/envs/utils.py
+++ b/gym_sts/envs/utils.py
@@ -147,12 +147,20 @@ class ActionValidators:
         # if target_index is not None and not potion.requires_target:
         #     return False
 
-        if target_index is None and potion.requires_target:
-            return False
+        if potion.requires_target:
+            # Explosive Potion is basically incorrectly defined within STS.
+            # It doesn't actually require a target.
+            if potion.id == "Explosive Potion":
+                return True
 
-        enemies = observation.combat_state.enemies
-        if target_index is not None and target_index >= len(enemies):
-            return False
+            if target_index is None:
+                return False
+
+            # Unlike when playing cards, STS disregards out-of-range target indices
+            # when using potions that don't take a target.
+            enemies = observation.combat_state.enemies
+            if target_index >= len(enemies):
+                return False
 
         return True
 


### PR DESCRIPTION
Potion target indices have to be in bounds only if the potion actually takes a target. For example, STS considers it valid to specify a target when using a dexterity potion, even though the dexterity potion doesn't take a target at all. The explosive potion is also an exception, because despite "requiring a target," it doesn't actually require a target index.