### PR TITLE
Simplify reset process, don't rely on clicks

### DIFF
--- a/gym_sts/communication/communicator.py
+++ b/gym_sts/communication/communicator.py
@@ -62,6 +62,12 @@ class Communicator:
         state = self.receiver.receive_game_state()
         return Observation(state)
 
+    def resign(self) -> Observation:
+        self.receiver.empty_fifo()
+        self.sender.send_resign()
+        state = self.receiver.receive_game_state()
+        return Observation(state)
+
     def start(self, player_class: str, ascension: int, seed: str) -> Observation:
         self.receiver.empty_fifo()
         self.sender.send_start(player_class, ascension, seed)

--- a/gym_sts/communication/sender.py
+++ b/gym_sts/communication/sender.py
@@ -34,6 +34,9 @@ class Sender:
     def send_potion(self, action, slot, target) -> None:
         self._send_message(f"POTION {action} {slot} {target}")
 
+    def send_resign(self) -> None:
+        self._send_message("RESIGN")
+
     def send_wait(self, frames: int) -> None:
         self._send_message(f"WAIT {frames}")
 

--- a/gym_sts/envs/base.py
+++ b/gym_sts/envs/base.py
@@ -181,40 +181,7 @@ class SlayTheSpireGymEnv(gym.Env):
             return
 
         # If still alive
-        # TODO(collin): document/clean this up
-        if not obs.game_over:
-            # Open the menu in the upper right of the screen
-            self.communicator.click(1900, 10)
-
-            # Click "abandon run"
-            self.communicator.click(1500, 240)
-            self.communicator.click(1500, 240)
-
-            # Confirm
-            self.communicator.click(830, 700)
-            self.communicator.click(830, 700)
-
-            # Acknowledge death
-            self.communicator.click(950, 920)
-            self.communicator.click(950, 920)
-
-            # Return to main menu
-            self.communicator.click(950, 950)
-            self.communicator.click(950, 950)
-        else:
-            # Acknowledge death
-            self.communicator.click(950, 920)
-            self.communicator.click(950, 920)
-
-            # Return to main menu
-            self.communicator.click(950, 950)
-            self.communicator.click(950, 950)
-
-        # TODO have a loop limit to prevent infinite loop
-        while True:
-            obs = self.observe()
-            if not obs.in_game:
-                break
+        self.communicator.resign()
 
     def observe(self, add_to_cache: bool = False) -> Observation:
         """


### PR DESCRIPTION
Use the new "resign" action available in our communicationmod fork to eliminate the need for clicks, which we've found to be unreliable.