### PR TITLE
Add render command

### DIFF
--- a/gym_sts/communication/communicator.py
+++ b/gym_sts/communication/communicator.py
@@ -112,3 +112,12 @@ class Communicator:
         self.sender.send_basemod(command)
         state = self.receiver.receive_game_state()
         return Observation(state)
+
+    def render(self, render: bool) -> None:
+        """
+        Toggle whether or not the game should render to the screen.
+
+        Note that this command does not return a state response.
+        """
+
+        self.sender.send_render(render)

--- a/gym_sts/communication/sender.py
+++ b/gym_sts/communication/sender.py
@@ -50,3 +50,6 @@ class Sender:
 
     def send_basemod(self, command: str) -> None:
         self._send_message(f"BASEMOD {command}")
+
+    def send_render(self, render: bool) -> None:
+        self._send_message(f"RENDER {render}")

--- a/gym_sts/test_valid_actions.py
+++ b/gym_sts/test_valid_actions.py
@@ -21,6 +21,7 @@ def main():
     parser.add_argument("out_dir")
     parser.add_argument("--build_image", action="store_true")
     parser.add_argument("--headless", action="store_true")
+    parser.add_argument("--render", action="store_true")
     parser.add_argument("--runtime", default=30, type=int)
     parser.add_argument("--allow_invalid", action="store_true")
     parser.add_argument("--screenshots", action="store_true")
@@ -31,6 +32,7 @@ def main():
     env = SlayTheSpireGymEnv(
         args.lib_dir, args.mods_dir, args.out_dir, headless=args.headless
     )
+    env.communicator.render(args.render)
     env.reset(seed=42)
     rng = random.Random(42)
 


### PR DESCRIPTION
Adds support for the "render" command added to https://github.com/kronion/CommunicationModPlus. Disabling rendering increases APS when running headlessly.