### PR TITLE
Validate boss reward actions

### DIFF
--- a/gym_sts/envs/action_validation.py
+++ b/gym_sts/envs/action_validation.py
@@ -40,6 +40,7 @@ def validate_choose(action: actions.Choose, observation: Observation) -> bool:
             print("NOT IMPLEMENTED")
             return False
     elif observation.screen_type in [
+        "BOSS_REWARD",
         "CARD_REWARD",
         "CHEST",
         "COMBAT_REWARD",


### PR DESCRIPTION
Ensures that only three choices are valid once the boss chest is opened. You can test by using basemod:
```
act boss
kill all
```