### PR TITLE
Hard reboots

### DIFF
--- a/gym_sts/envs/types.py
+++ b/gym_sts/envs/types.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+class ResetParams(BaseModel):
+    """
+    Pydantic model for validating reset() arguments.
+    """
+
+    seed: Optional[int]
+    return_info: bool
+    sts_seed: Optional[str]
+    rng_state: Optional[tuple]
+    reboot: bool = False
+
+    @validator("rng_state")
+    def seed_and_rng_state_are_mutually_exclusive(cls, v, values, **kwargs):
+        if values.get("seed") is not None and v is not None:
+            raise ValueError("seed and rng_state cannot both be provided")
+        return v

--- a/tests/env/test_rebooting.py
+++ b/tests/env/test_rebooting.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+
+
+def test_reboot_occurs_every_reset(env):
+    env.reboot_frequency = 1
+
+    with patch.object(env, "_end_game") as mock_end_game:
+        env.reset()
+        env.reset()
+        env.reset()
+
+    mock_end_game.assert_not_called()

--- a/tests/env/test_rebooting.py
+++ b/tests/env/test_rebooting.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 
 def test_reboot_occurs_every_reset(env):
+    env.reset_count = 0
     env.reboot_frequency = 1
 
     with patch.object(env, "_end_game") as mock_end_game:
@@ -10,3 +11,44 @@ def test_reboot_occurs_every_reset(env):
         env.reset()
 
     mock_end_game.assert_not_called()
+
+
+def test_reboot_occurs_only_once(env):
+    env.reset_count = 0
+    env.reboot_frequency = 0
+    env.reset()
+
+    with patch.object(env, "reboot") as mock_reboot:
+        env.reset()
+        env.reset()
+        mock_reboot.assert_not_called()
+
+
+def test_reboot_occurs_every_other_time(env):
+    env.reset_count = 0
+    env.reboot_frequency = 2
+
+    with patch.object(env, "_end_game", side_effect=env._end_game) as mock_end_game:
+        with patch.object(env, "reboot", side_effect=env.reboot) as mock_reboot:
+            for i in range(6):
+                env.reset()
+                if i % 2 == 0:
+                    mock_reboot.assert_called_once()
+                else:
+                    mock_end_game.assert_called_once()
+
+                mock_reboot.reset_mock()
+                mock_end_game.reset_mock()
+
+
+def test_force_reboot(env):
+    env.reset_count = 0
+    env.reboot_frequency = 0
+    env.reset()
+
+    with patch.object(env, "reboot", side_effect=env.reboot) as mock_reboot:
+        env.reset()
+        mock_reboot.assert_not_called()
+
+        env.reset(options={"reboot": True})
+        mock_reboot.assert_called_once()


### PR DESCRIPTION
- Add a `reboot_frequency` kwarg to the env constructor. Every nth `reset()` will (re)boot the game from scratch.
- Add support for a `reboot` option for `reset()`. When `True`, the game will be rebooted from scratch.
- Add tests of new reboot behavior
- Use pydantic to validate arguments for `reset()`