### PR TITLE
Use the ray 2.x APIs

### DIFF
--- a/gym_sts/rl/mvp.py
+++ b/gym_sts/rl/mvp.py
@@ -71,11 +71,15 @@ WANDB = ff.DEFINE_dict(
 
 RL = ff.DEFINE_dict(
     "rl",
-    num_workers=ff.Integer(0),
     rollout_fragment_length=ff.Integer(32),
     train_batch_size=ff.Integer(1024),
 )
 
+SCALING = ff.DEFINE_dict(
+    "scaling",
+    num_workers=ff.Integer(0),
+    use_gpu=ff.Boolean(False),
+)
 
 class Env(base.SlayTheSpireGymEnv):
     def __init__(self, cfg: dict):
@@ -102,7 +106,6 @@ def main(_):
         base.SlayTheSpireGymEnv.build_image()
 
     rl_config = RL.value.copy()
-    num_workers = rl_config.pop("num_workers")
 
     ppo_config = {
         "env": Env,
@@ -119,7 +122,7 @@ def main(_):
     ppo_config.update(rl_config)
 
     trainer = RLTrainer(
-        scaling_config=config.ScalingConfig(num_workers=num_workers, use_gpu=True),
+        scaling_config=config.ScalingConfig(**SCALING.value),
         algorithm=ppo.PPO,
         config=ppo_config,
     )

--- a/gym_sts/rl/mvp.py
+++ b/gym_sts/rl/mvp.py
@@ -41,12 +41,15 @@ ENV = ff.DEFINE_dict(
 
 TUNE = ff.DEFINE_dict(
     "tune",
+    name=ff.String("sts-rl", "Name of the ray experiment"),
     checkpoint_config=dict(
         checkpoint_frequency=ff.Integer(20),
         checkpoint_at_end=ff.Boolean(False),
         num_to_keep=ff.Integer(3),
     ),
-    restore=ff.String(None, "path to checkpoint to restore from"),
+    restore=ff.String(
+        None, "Path to experiment directory to restore from, e.g. ~/ray_results/sts-rl"
+    ),
     sync_config=dict(
         upload_dir=ff.String(None, "Path to local or remote folder."),
         syncer=ff.String("auto"),
@@ -131,6 +134,7 @@ def main(_):
     sync_config = tune.SyncConfig(**tune_config["sync_config"])
     checkpoint_config = config.CheckpointConfig(**tune_config["checkpoint_config"])
     run_config = config.RunConfig(
+        name=tune_config["name"],
         callbacks=callbacks,
         checkpoint_config=checkpoint_config,
         sync_config=sync_config,


### PR DESCRIPTION
- Use `Tuner.fit()` instead of `tune.run()`
- Parse `tune_config` into separate config objects for use by various classes in the 2.x API (e.g. `RunConfig`, `SyncConfig`, `CheckpointConfig`).