### PR TITLE
Add screen_type to observation

### DIFF
--- a/gym_sts/spaces/constants.py
+++ b/gym_sts/spaces/constants.py
@@ -1128,3 +1128,20 @@ COMBAT_REWARD_LOG_MAX_ID = math.ceil(math.log(_COMBAT_REWARD_MAX_ID, 2))
 
 # (Card + gold + potion + 2 relics (black star) + key) * buffer in case I'm wrong
 MAX_NUM_REWARDS = int((1 + 1 + 1 + 2 + 1) * 1.25)
+
+ALL_SCREEN_TYPES = [
+    "EMPTY",  # Indicates the absence of a screen type
+    "BOSS_REWARD",  # The contents of the boss chest
+    "CARD_REWARD",
+    "CHEST",
+    "COMBAT_REWARD",
+    "EVENT",
+    "GAME_OVER",
+    "GRID",  # The contents of card piles, e.g. the discard
+    "HAND_SELECT",
+    "MAP",
+    "NONE",  # Has several meanings, e.g. combat
+    "REST",
+    "SHOP_ROOM",  # The room containing the merchant
+    "SHOP_SCREEN",  # The actual shopping menu
+]

--- a/gym_sts/spaces/observations/components/persistent.py
+++ b/gym_sts/spaces/observations/components/persistent.py
@@ -1,4 +1,4 @@
-from gym.spaces import Dict, MultiBinary, MultiDiscrete
+from gym.spaces import Dict, Discrete, MultiBinary, MultiDiscrete
 from pydantic import parse_obj_as
 
 from gym_sts.spaces import constants
@@ -20,6 +20,7 @@ class PersistentStateObs(ObsComponent):
         self.deck = []
         self.keys = {}
         self.map = MapObs()
+        self.screen_type = "EMPTY"
 
         if "game_state" in state:
             game_state = state["game_state"]
@@ -31,6 +32,7 @@ class PersistentStateObs(ObsComponent):
             self.relics = parse_obj_as(list[types.Relic], game_state["relics"])
             self.deck = parse_obj_as(list[types.Card], game_state["deck"])
             self.map = MapObs(state)
+            self.screen_type = game_state["screen_type"]
 
             if "keys" in game_state:
                 self.keys = game_state["keys"]
@@ -49,6 +51,7 @@ class PersistentStateObs(ObsComponent):
                 "deck": spaces.generate_card_space(),
                 "keys": MultiBinary(constants.NUM_KEYS),
                 "map": MapObs.space(),
+                "screen_type": Discrete(len(constants.ALL_SCREEN_TYPES)),
             }
         )
 
@@ -74,6 +77,8 @@ class PersistentStateObs(ObsComponent):
                 _keys[i] = self.keys[key]
         keys = [int(key) for key in _keys]
 
+        screen_type = constants.ALL_SCREEN_TYPES.index(self.screen_type)
+
         response = {
             "health": health,
             "gold": gold,
@@ -82,6 +87,7 @@ class PersistentStateObs(ObsComponent):
             "deck": deck,
             "keys": keys,
             "map": self.map.serialize(),
+            "screen_type": screen_type,
         }
 
         return response


### PR DESCRIPTION
I ended up needing to add this to the observation in order to log stats that are screen-specific, e.g. which action was taken in a rest stop.