### PR TITLE
Fix enemy overflow serde bug

### DIFF
--- a/gym_sts/envs/action_validation.py
+++ b/gym_sts/envs/action_validation.py
@@ -98,13 +98,6 @@ def validate_play(action: actions.PlayCard, observation: Observation) -> bool:
         if target_index >= len(enemies):
             return False
 
-        # We confirm the card actually takes a target. If it doesn't, the target
-        # selection is ignored anyway.
-        if card.has_target:
-            enemy = enemies[target_index]
-            if enemy.is_gone:
-                return False
-
     return card.is_playable
 
 

--- a/gym_sts/spaces/actions.py
+++ b/gym_sts/spaces/actions.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Optional
 
 from gym.spaces import Discrete
@@ -7,9 +8,10 @@ from gym_sts.spaces import old_constants as constants
 from gym_sts.spaces.constants import potions as potion_consts
 
 
-class Action(BaseModel):
+class Action(BaseModel, ABC):
     _id: int = PrivateAttr(-1)
 
+    @abstractmethod
     def to_command(self) -> str:
         raise RuntimeError("not implemented")
 

--- a/gym_sts/spaces/observations/components/combat.py
+++ b/gym_sts/spaces/observations/components/combat.py
@@ -53,10 +53,7 @@ class CombatObs(ObsComponent):
             self.exhaust = [types.Card(**card) for card in combat_state["exhaust_pile"]]
             self.exhaust.sort()
 
-            enemies = [types.Enemy(**enemy) for enemy in combat_state["monsters"]]
-            # CommunicationMod continues to send data for killed enemies/minions,
-            # so we need to filter them out.
-            self.enemies = [e for e in enemies if not e.is_gone]
+            self.enemies = [types.Enemy(**enemy) for enemy in combat_state["monsters"]]
             assert len(self.enemies) <= constants.NUM_ENEMIES
 
             player_state = combat_state["player"]

--- a/gym_sts/spaces/observations/types/base.py
+++ b/gym_sts/spaces/observations/types/base.py
@@ -188,7 +188,6 @@ class Enemy(BaseModel):
     max_hp: int = Field(..., ge=0, lt=2**constants.LOG_MAX_HP)
     block: int = Field(..., ge=0, lt=2**constants.LOG_MAX_BLOCK)
     effects: list[Effect] = Field([], alias="powers")
-    is_gone: bool = False  # TODO serialize?
 
     # These attribues may not be set if the player has runic dome
     damage: int = Field(

--- a/tests/observations/serde/test_combat.py
+++ b/tests/observations/serde/test_combat.py
@@ -25,7 +25,7 @@ def test_dead_minions_dont_overflow_serde_bounds(env: SlayTheSpireGymEnv):
     overflow the bounds of the serialization representation.
     """
 
-    env.reset()
+    env.reset(seed=42)
 
     # Enter combat
     env.communicator.basemod("fight Reptomancer")
@@ -33,7 +33,7 @@ def test_dead_minions_dont_overflow_serde_bounds(env: SlayTheSpireGymEnv):
     # Add enough HP that we can just wait for tons of minions to spawn and kamikaze
     env.communicator.basemod("maxhp add 900")
 
-    for _ in range(20):
+    for _ in range(22):
         obs = env.observe(add_to_cache=True)
         orig_state = obs.combat_state
         ser = orig_state.serialize()
@@ -43,3 +43,10 @@ def test_dead_minions_dont_overflow_serde_bounds(env: SlayTheSpireGymEnv):
 
         # End turn
         env.step(0)
+
+    # Confirm that attacking a specific enemy index works as expected.
+    # We attack one of Reptomancer's daggers and confirm that its health decreases.
+    env.step(75)
+    obs = env.observe(add_to_cache=True)
+    enemies = obs.combat_state.enemies
+    assert enemies[1].current_hp == 16

--- a/tests/observations/serde/test_combat.py
+++ b/tests/observations/serde/test_combat.py
@@ -13,3 +13,33 @@ def test_combat_serde(env: SlayTheSpireGymEnv):
     de = obs.combat_state.deserialize(ser)
 
     assert orig_state == de
+
+
+def test_dead_minions_dont_overflow_serde_bounds(env: SlayTheSpireGymEnv):
+    """
+    Combats with large numbers of minions shouldn't cause exceptions during serde.
+
+    There should only be up to 6 enemies on-screen at a time, but
+    CommunicationMod continues to send data about dead enemies/minions.
+    Confirm that we filter out the dead enemies/minions to guarantee we don't
+    overflow the bounds of the serialization representation.
+    """
+
+    env.reset()
+
+    # Enter combat
+    env.communicator.basemod("fight Reptomancer")
+
+    # Add enough HP that we can just wait for tons of minions to spawn and kamikaze
+    env.communicator.basemod("maxhp add 900")
+
+    for _ in range(20):
+        obs = env.observe(add_to_cache=True)
+        orig_state = obs.combat_state
+        ser = orig_state.serialize()
+        de = obs.combat_state.deserialize(ser)
+
+        assert orig_state.enemies == de.enemies
+
+        # End turn
+        env.step(0)


### PR DESCRIPTION
Fixes a bug where combat serialization would fail because dead enemies/minions would still be encoded, causing us to exceed the max number of enemies that could be encoded. Here's an example of the traceback we were seeing:
```cli
sts/gym_sts/spaces/observations/components/combat.py", line 98, in serialize
    enemies[i] = enemy.serialize()
IndexError: list assignment index out of range
```

Note that the position of an enemy can now change in the serialization, if an enemy before it gets killed.

You can test like this: `pytest -x --pdb tests/observations/serde/test_combat.py`