### PR TITLE
Log steps as list

### DIFF
--- a/gym_sts/constants.py
+++ b/gym_sts/constants.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+
 PROJECT_ROOT = Path(__file__).parent.absolute()
 
 JAVA_INSTALL = "/usr/bin/java"

--- a/gym_sts/data/state_log_loader.py
+++ b/gym_sts/data/state_log_loader.py
@@ -1,14 +1,22 @@
 import json
 from typing import TextIO
 
+from pydantic import BaseModel
+
 from gym_sts.spaces.actions import ACTIONS
 from gym_sts.spaces.observations import Observation
 
 
+class Step(BaseModel):
+    state_before: dict
+    action: int
+    state_after: dict
+
+
 class StateLogLoader:
     def __init__(self):
-        self.state_data = []
-        self.step_data = {"state_before": [], "action": [], "state_after": []}
+        self.observations = []
+        self.steps = []
 
     def load_file(self, fh: TextIO):
         objs = json.load(fh)
@@ -20,12 +28,12 @@ class StateLogLoader:
         for obj in objs:
             cur_obs = Observation(obj["state_after"]).serialize()
 
-            self.state_data.append(cur_obs)
+            self.observations.append(cur_obs)
 
             # Store step data
             if prev_obs and obj["action"]:
-                self.step_data["state_before"].append(prev_obs)
-                self.step_data["action"].append(action_strings.index(obj["action"]))
-                self.step_data["state_after"].append(cur_obs)
+                action = action_strings.index(obj["action"])
+                step = Step(state_before=prev_obs, action=action, state_after=cur_obs)
+                self.steps.append(step)
 
             prev_obs = cur_obs

--- a/gym_sts/env_repl.py
+++ b/gym_sts/env_repl.py
@@ -2,6 +2,7 @@
 
 from gym_sts.envs.base import SlayTheSpireGymEnv
 
+
 SlayTheSpireGymEnv.build_image()
 env = SlayTheSpireGymEnv("lib", "mods", "out", headless=True)
 obs = env.reset()

--- a/gym_sts/rl/utils.py
+++ b/gym_sts/rl/utils.py
@@ -2,6 +2,7 @@ import typing as tp
 
 from gym import spaces
 
+
 def assert_contains(space: spaces.Space, element: tp.Any):
     """Use with post-mortem debugging to see where in the space the error is."""
     if isinstance(space, spaces.Dict):

--- a/gym_sts/test_valid_actions.py
+++ b/gym_sts/test_valid_actions.py
@@ -37,7 +37,9 @@ def main():
     if args.build_image:
         SlayTheSpireGymEnv.build_image()
     env = SlayTheSpireGymEnv(
-        args.lib_dir, args.mods_dir, args.out_dir,
+        args.lib_dir,
+        args.mods_dir,
+        args.out_dir,
         headless=args.headless,
         animate=args.render,
         reboot_on_error=True,
@@ -104,7 +106,7 @@ def main():
 
     if args.dump_states:
         states_file = os.path.join(args.out_dir, "states.pkl")
-        with open(states_file, 'wb') as f:
+        with open(states_file, "wb") as f:
             column_major = tree.map_structure(lambda *xs: np.array(xs), *states)
             pickle.dump(column_major, f)
 


### PR DESCRIPTION
Log step data as a list of objects. No need to be column-major here, we convert the data to column major in sts-playground. It's actually easier to massage it into column-major if we get to operate on a list of dicts. It's also more straightforward for basic uses like, "look at what I did at step n."