### PR TITLE
Disable particle effects

### DIFF
--- a/gym_sts/build/preferences/STSGameplaySettings
+++ b/gym_sts/build/preferences/STSGameplaySettings
@@ -3,7 +3,7 @@
   "Blocked Damage": "true",
   "Hand Confirmation": "false",
   "Upload Data": "false",
-  "Particle Effects": "false",
+  "Particle Effects": "true",
   "Fast Mode": "true",
   "Show Card keys": "false",
   "Bigger Text": "false",


### PR DESCRIPTION
This setting is poorly named on the back-end. In the game settings menu, the checkbox is titled "Disable particle effects." true = disable.