### PR TITLE
Assorted env fixes

### DIFF
--- a/gym_sts/spaces/constants/base.py
+++ b/gym_sts/spaces/constants/base.py
@@ -26,6 +26,7 @@ class ScreenType(str, Enum):
     CARD_REWARD = "CARD_REWARD"
     CHEST = "CHEST"
     COMBAT_REWARD = "COMBAT_REWARD"
+    COMPLETE = "COMPLETE"  # The screen immediately after defeating the Act 3/4 boss?
     EVENT = "EVENT"
     FTUE = "FTUE"
     GAME_OVER = "GAME_OVER"

--- a/gym_sts/spaces/constants/cards.py
+++ b/gym_sts/spaces/constants/cards.py
@@ -1294,8 +1294,8 @@ class _CardCatalog:
                 has_target=True,
             ),
         ),
-        "Cloak and Dagger": CardMetadata(
-            id="Cloak and Dagger",
+        "Cloak And Dagger": CardMetadata(
+            id="Cloak And Dagger",
             name="Cloak and Dagger",
             card_type=CardType.SKILL,
             unupgraded=CardProperties(

--- a/gym_sts/spaces/constants/combat.py
+++ b/gym_sts/spaces/constants/combat.py
@@ -12,7 +12,7 @@ LOG_MAX_ATTACK = math.ceil(math.log(MAX_ATTACK, 2))
 LOG_MAX_ATTACK_TIMES = math.ceil(math.log(MAX_ATTACK_TIMES, 2))
 LOG_MAX_BLOCK = math.ceil(math.log(MAX_BLOCK, 2))
 LOG_MAX_EFFECT = math.ceil(math.log(MAX_EFFECT, 2))
-LOG_MAX_ENERGY = 4
+LOG_MAX_ENERGY = 6
 LOG_MAX_TURN = 8
 
 ALL_EFFECTS = [


### PR DESCRIPTION
- Add the "COMPLETE" state to ScreenType. This state is reached at the end of the Act 3 boss, instead of a combat reward.
- Use the correct ID for Cloak And Dagger. This fixes a bug in CommunicationMod response parsing.
- Increase the maximum allowable energy from 15 to 63